### PR TITLE
fix: prevent vertically truncated avatar images

### DIFF
--- a/src/WeAreDotNet.MobileApp/Views/MainPage.xaml
+++ b/src/WeAreDotNet.MobileApp/Views/MainPage.xaml
@@ -26,7 +26,7 @@
                             <TapGestureRecognizer Command="{Binding Path=BindingContext.FeedItemSelectedCommand, Source={x:Reference mainPage}}" CommandParameter="{Binding .}" />
                         </VerticalStackLayout.GestureRecognizers>
                         <Frame CornerRadius="20" Padding="0" BackgroundColor="{StaticResource Primary}" IsClippedToBounds="True" HasShadow="False" BorderColor="{StaticResource Primary}">
-                            <Grid RowDefinitions="200,75,25" HeightRequest="350" RowSpacing="5">
+                            <Grid RowDefinitions="200,75,30" HeightRequest="350" RowSpacing="5">
                                 <Image Grid.Row="0" Source="{Binding PreviewImage}" HeightRequest="200" Aspect="AspectFill" />
 
                                 <Border Grid.Row="0" VerticalOptions="End" HorizontalOptions="Start" Padding="5" Margin="10"


### PR DESCRIPTION
Avatars were previously truncated vertically, at the bottom, like this
![image](https://github.com/WeAreDotnet/mobile-app/assets/79252299/91a2afc6-3da8-4efb-9d30-782eca12459f)

now fixed.