### PR TITLE
fix: correct profile page avatar truncation, full radius

### DIFF
--- a/src/WeAreDotNet.MobileApp/Views/ProfilePage.xaml
+++ b/src/WeAreDotNet.MobileApp/Views/ProfilePage.xaml
@@ -18,10 +18,10 @@
             <Grid ColumnDefinitions="100,*" ColumnSpacing="10">
                 <Image Grid.Column="0" Grid.RowSpan="2" VerticalOptions="Center"
                        Source="{Binding UserProfile.Picture}" WidthRequest="100"
-                       HeightRequest="100" Margin="0,0,10,0">
+                       HeightRequest="100" Margin="0,0,0,0">
                     <Image.Clip>
                         <RoundRectangleGeometry
-                            CornerRadius="12"
+                            CornerRadius="50"
                             Rect="0,0,100,100" />
                     </Image.Clip>
                 </Image>


### PR DESCRIPTION
on the Profile Page, avatars were previously truncated on the right hand side (by 10 pixels), and the radius did not match the rest of the app

changed from this
![image](https://github.com/WeAreDotnet/mobile-app/assets/79252299/4caac408-1835-4376-a98b-d3a7be4b06f2)

to this
![image](https://github.com/WeAreDotnet/mobile-app/assets/79252299/f98965af-30a5-4551-9ab7-2b52aa2b17c5)
