### PR TITLE
fix: member page avatar was truncated

### DIFF
--- a/src/WeAreDotNet.MobileApp/Views/MembersOverviewPage.xaml
+++ b/src/WeAreDotNet.MobileApp/Views/MembersOverviewPage.xaml
@@ -17,7 +17,7 @@
                     <VerticalStackLayout.GestureRecognizers>
                         <TapGestureRecognizer Command="{Binding Path=BindingContext.MemberSelectedCommand, Source={x:Reference membersOverviewPage}}" CommandParameter="{Binding Nickname}" />
                     </VerticalStackLayout.GestureRecognizers>
-                    <Frame CornerRadius="20" Padding="5" BackgroundColor="{StaticResource UserBackground}" IsClippedToBounds="True" HasShadow="False" BorderColor="{StaticResource UserBackground}">
+                    <Frame CornerRadius="5" HeightRequest="95" Padding="5" BackgroundColor="{StaticResource UserBackground}" IsClippedToBounds="False" HasShadow="False" BorderColor="{StaticResource UserBackground}">
                         <Grid ColumnDefinitions="100,*" ColumnSpacing="10">
                             <Image Grid.Column="0" Grid.RowSpan="2" VerticalOptions="Center"
                                     Source="{Binding Picture}" WidthRequest="80"


### PR DESCRIPTION
changed from this:
![image](https://github.com/WeAreDotnet/mobile-app/assets/79252299/cefd7446-7f2a-4292-b63d-f8a0a89af33b)

to this:
![image](https://github.com/WeAreDotnet/mobile-app/assets/79252299/34beaab9-d36a-4297-8c07-537a11dd588e)
